### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/examples/autogen_examples/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
+++ b/examples/autogen_examples/autogen/agentchat/contrib/retrieve_user_proxy_agent.py
@@ -8,7 +8,7 @@ from IPython import get_ipython
 try:
     import chromadb
 except ImportError:
-    raise ImportError("Please install dependencies first. `pip install pyautogen[retrievechat]`")
+    raise ImportError("Please install dependencies first. `pip install ag2[retrievechat]`")
 from autogen.agentchat import UserProxyAgent
 from autogen.agentchat.agent import Agent
 from autogen.agentchat.contrib.vectordb.base import Document, QueryResults, VectorDB, VectorDBFactory


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
